### PR TITLE
Allow generic extensions for any type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytes"
@@ -225,7 +225,6 @@ dependencies = [
  "indexmap",
  "num-bigint",
  "num-traits",
- "once_cell",
  "serde",
  "serde_json",
  "tempfile",
@@ -299,9 +298,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -309,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "form_urlencoded"
@@ -457,9 +456,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libtest-mimic"
@@ -474,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -716,11 +715,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -860,14 +859,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1154,7 +1154,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1174,17 +1183,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1195,9 +1205,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1207,9 +1217,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1219,9 +1229,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1231,9 +1247,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1243,9 +1259,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1255,9 +1271,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1267,6 +1283,6 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,21 @@ edition = "2021"
 anyhow = "1.0.71"
 clap = { version = "4.3.8", features = ["derive"] }
 dashmap = "5.5.3"
-datatest-stable = "0.2.3"
 derive_more = "0.99.17"
 either = "1.10.0"
 enum-as-inner = "0.6.0"
 indexmap = "2.0.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
-once_cell = "1.19.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
-tempfile = "3.10.1"
 tokio = { version = "1.36.0", features = ["full"] }
 tower-lsp = "0.20.0"
 unicode-xid = "0.2.4"
+
+[dev-dependencies]
+datatest-stable = "0.2.3"
+tempfile = "3.10.1"
 wait-timeout = "0.2.0"
 
 [[test]]

--- a/ctl/core/main.ctl
+++ b/ctl/core/main.ctl
@@ -13,7 +13,5 @@ mod prelude {
     pub use super::opt::Option::Some;
     pub use super::iter::Iterator;
     pub use super::ext::*;
-    pub use super::span::SpanEq;
-    pub use super::span::SpanMutEq;
-    pub use super::span::SpanMutSort;
+    pub use super::span::ext::*;
 }

--- a/ctl/core/main.ctl
+++ b/ctl/core/main.ctl
@@ -14,4 +14,5 @@ mod prelude {
     pub use super::iter::Iterator;
     pub use super::ext::*;
     pub use super::span::ext::*;
+    pub use super::opt::ext::*;
 }

--- a/ctl/core/main.ctl
+++ b/ctl/core/main.ctl
@@ -13,4 +13,7 @@ mod prelude {
     pub use super::opt::Option::Some;
     pub use super::iter::Iterator;
     pub use super::ext::*;
+    pub use super::span::SpanEq;
+    pub use super::span::SpanMutEq;
+    pub use super::span::SpanMutSort;
 }

--- a/ctl/core/opt.ctl
+++ b/ctl/core/opt.ctl
@@ -47,3 +47,20 @@ pub union Option<T> {
         }
     }
 }
+
+pub mod ext {
+    pub extension OptionFormat<T: core::fmt::Format> for ?T {
+        impl core::fmt::Format {
+            fn format<F: core::fmt::Formatter>(this, f: *mut F) {
+                if this is ?rhs {
+                    "Some(".format(f);
+                    rhs.format(f);
+                    ")".format(f);
+                } else {
+                    "null".format(f);
+                }
+            }
+        }
+    }
+}
+

--- a/ctl/core/span.ctl
+++ b/ctl/core/span.ctl
@@ -68,6 +68,16 @@ pub struct Span<T> {
         unsafe Span::new(this.ptr + start, end - start)
     }
 
+    pub fn first(this): ?*T {
+        this.get(0)
+    }
+
+    pub fn last(this): ?*T {
+        if !this.is_empty() {
+            unsafe this.get_unchecked(this.len() - 1)
+        }
+    }
+
     #(inline)
     pub fn []<I: Numeric + Integral>(this, idx: I): *T {
         unsafe raw_subscript_checked(this.ptr, this.len, idx) as *T
@@ -177,6 +187,26 @@ pub struct SpanMut<T> {
         core::mem::swap(&mut this[a], &mut this[b]);
     }
 
+    pub fn first(this): ?*T {
+        this.get(0)
+    }
+
+    pub fn first_mut(this): ?*mut T {
+        this.get_mut(0)
+    }
+
+    pub fn last(this): ?*T {
+        if !this.is_empty() {
+            unsafe this.get_unchecked(this.len() - 1)
+        }
+    }
+
+    pub fn last_mut(this): ?*mut T {
+        if !this.is_empty() {
+            unsafe this.get_mut_unchecked(this.len() - 1)
+        }
+    }
+
     #(inline)
     pub fn []<I: Numeric + Integral>(this, idx: I): *mut T {
         unsafe raw_subscript_checked(this.ptr, this.len, idx) as *mut T
@@ -248,36 +278,6 @@ pub struct IterMut<T> {
     }
 }
 
-// TODO: make this a member function for T: Eq types
-pub fn compare<T>(lhs: [T..], rhs: [T..]): bool {
-    if lhs.len() != rhs.len() {
-        return false;
-    }
-
-    unsafe core::mem::compare(lhs.ptr, rhs.ptr, lhs.len())
-}
-
-// TODO: make this a member function
-pub fn sort<T: core::ops::Cmp<T>>(span: [mut T..]) {
-    guard !span.is_empty() else {
-        return;
-    }
-
-    let end      = span.len() - 1;
-    let pivot    = &span[end];
-    mut part_idx = 0u;
-    for j in 0u..end {
-        if span[j] <= pivot {
-            span.swap(part_idx, j);
-            part_idx++;
-        }
-    }
-
-    span.swap(part_idx, end);
-    sort(span[0u..part_idx]);
-    sort(span[part_idx + 1..]);
-}
-
 #(inline(always))
 fn raw_subscript_checked<T, I: Numeric + Integral>(ptr: *raw T, len: uint, idx: I): *raw T {
     if !core::intrin::numeric_lt(idx, len) or idx < core::intrin::numeric_cast(0) {
@@ -285,4 +285,50 @@ fn raw_subscript_checked<T, I: Numeric + Integral>(ptr: *raw T, len: uint, idx: 
     }
 
     core::intrin::raw_offset(ptr, idx)
+}
+
+// TODO: make these member functions/impls when the syntax allows for it
+
+pub extension SpanEq<T: core::ops::Eq<T>> for [T..] {
+    pub fn ==(this, rhs: *[T..]): bool {
+        if this.len() != rhs.len() {
+            return false;
+        }
+
+        for (l, r) in this.iter().zip::<*T, Iter<T>>(rhs.iter()) {
+            if l != r {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+pub extension SpanMutEq<T: core::ops::Eq<T>> for [mut T..] {
+    pub fn ==(this, rhs: *[T..]): bool {
+        this.as_span() == rhs
+    }
+}
+
+pub extension SpanMutSort<T: core::ops::Cmp<T>> for [mut T..] {
+    pub fn sort(this) {
+        guard !this.is_empty() else {
+            return;
+        }
+
+        let end      = this.len() - 1;
+        let pivot    = &this[end];
+        mut part_idx = 0u;
+        for j in 0u..end {
+            if this[j] <= pivot {
+                this.swap(part_idx, j);
+                part_idx++;
+            }
+        }
+
+        this.swap(part_idx, end);
+        this[0u..part_idx].sort();
+        this[part_idx + 1..].sort();
+    }
 }

--- a/ctl/core/string.ctl
+++ b/ctl/core/string.ctl
@@ -72,7 +72,10 @@ pub struct str {
 
     impl Eq<str> {
         fn eq(this, rhs: *str): bool {
-            core::span::compare(this.as_bytes(), rhs.as_bytes())
+            use core::span::SpanEq;
+            use core::ext::NumericExt;
+
+            this.as_bytes() == rhs.as_bytes()
         }
     }
 

--- a/ctl/core/string.ctl
+++ b/ctl/core/string.ctl
@@ -72,7 +72,7 @@ pub struct str {
 
     impl Eq<str> {
         fn eq(this, rhs: *str): bool {
-            use core::span::SpanEq;
+            use core::span::ext::SpanEq;
             use core::ext::NumericExt;
 
             this.as_bytes() == rhs.as_bytes()

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::{map::Entry, IndexMap};
 use num_bigint::BigInt;
 use num_traits::Num;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::{
     ast::{checked::*, declared::*, parsed::*, Attributes, BinaryOp, UnaryOp},
@@ -7242,7 +7242,7 @@ fn discriminant_bits(count: usize) -> u32 {
     (count as f64).log2().ceil() as u32
 }
 
-static BINARY_OP_TRAITS: Lazy<HashMap<BinaryOp, (&str, &str)>> = Lazy::new(|| {
+static BINARY_OP_TRAITS: LazyLock<HashMap<BinaryOp, (&str, &str)>> = LazyLock::new(|| {
     [
         (BinaryOp::Cmp, ("op_cmp", "cmp")),
         (BinaryOp::Gt, ("op_cmp", "gt")),
@@ -7265,7 +7265,7 @@ static BINARY_OP_TRAITS: Lazy<HashMap<BinaryOp, (&str, &str)>> = Lazy::new(|| {
     .into()
 });
 
-static UNARY_OP_TRAITS: Lazy<HashMap<UnaryOp, (&str, &str)>> = Lazy::new(|| {
+static UNARY_OP_TRAITS: LazyLock<HashMap<UnaryOp, (&str, &str)>> = LazyLock::new(|| {
     [
         (UnaryOp::Neg, ("op_neg", "neg")),
         (UnaryOp::Not, ("op_not", "not")),

--- a/src/typeid.rs
+++ b/src/typeid.rs
@@ -80,6 +80,10 @@ where
             ),
         )
     }
+
+    pub fn from_id_unknown(scopes: &Scopes, id: T) -> Self {
+        Self::from_type_args(scopes, id, std::iter::repeat(TypeId::UNKNOWN))
+    }
 }
 
 impl<T> WithTypeArgs<T> {
@@ -144,17 +148,7 @@ pub type GenericFunc = WithTypeArgs<FunctionId>;
 
 impl GenericFunc {
     pub fn from_id(scopes: &Scopes, id: FunctionId) -> Self {
-        Self::new(
-            id,
-            TypeArgs(
-                scopes
-                    .get(id)
-                    .type_params
-                    .iter()
-                    .map(|&id| (id, TypeId::UNKNOWN))
-                    .collect(),
-            ),
-        )
+        Self::from_id_unknown(scopes, id)
     }
 
     pub fn as_fn_ptr(&self, scopes: &Scopes, types: &mut Types) -> FnPtr {

--- a/tests/dyn/dependent.ctl
+++ b/tests/dyn/dependent.ctl
@@ -8,7 +8,7 @@ trait Bar: Foo { }
 
 struct Test {
     x: int,
-    
+
     impl Foo {
         fn foo(mut this, x: int) {
             this.x = x;

--- a/tests/ext/circular.ctl
+++ b/tests/ext/circular.ctl
@@ -1,0 +1,40 @@
+// Error: no method 'a' found on type 'int'
+// Error: no method 'b' found on type 'int'
+// Error: no method 'c' found on type 'int'
+
+trait Foo {}
+trait Bar {}
+trait Baz {}
+
+extension A<T: Baz> for T {
+    impl Foo {}
+
+    fn a(this) {}
+}
+
+extension B<T: Bar> for T {
+    impl Baz {}
+
+    fn b(this) {}
+}
+
+extension C<T: Foo> for T {
+    impl Bar {}
+
+    fn c(this) {}
+}
+
+struct Hello {
+    impl Foo {}
+}
+
+fn main() {
+    let x = Hello();
+    x.a();
+    x.b();
+    x.c();
+
+    10.a();
+    10.b();
+    10.c();
+}

--- a/tests/loop/for_iter.ctl
+++ b/tests/loop/for_iter.ctl
@@ -4,7 +4,7 @@
 
 fn main() {
     {
-        mut x = @[1, 2, 3, 4, 5];
+        mut x = [1, 2, 3, 4, 5][..];
         let y = for i in x.iter_mut() {
             if *i == 3 {
                 break i;
@@ -19,7 +19,7 @@ fn main() {
     }
 
     {
-        mut x = @[1, 2, 3, 4, 5];
+        mut x = [1, 2, 3, 4, 5][..];
         let y = for i in x.iter() {
             if *i == 5000 {
                 break *i;

--- a/tests/loop/for_while_generic.ctl
+++ b/tests/loop/for_while_generic.ctl
@@ -1,16 +1,16 @@
 // Output: 1 2 3 1 2 3
 
-fn test<T: std::fmt::Format>(t: *mut [T]) {
-    for item in t.iter_mut() {
+fn test<T: std::fmt::Format>(t: [T..]) {
+    for item in t.iter() {
         print("{item} ");
     }
 
-    mut t = t.iter_mut();
+    mut t = t.iter();
     while t.next() is ?item {
         print("{item} ");
     }
 }
 
 fn main() {
-    test::<int>(&mut @[1, 2, 3]);
+    test::<int>([1, 2, 3][..]);
 }

--- a/tests/loop/while_iter.ctl
+++ b/tests/loop/while_iter.ctl
@@ -1,7 +1,7 @@
 // Output: 10 true
 
 fn main() {
-    let x = @[1, 2, 3, 4];
+    let x = [1, 2, 3, 4][..];
     mut total = 0;
     mut iter = x.iter();
     while iter.next() is ?item {

--- a/tests/or_short_circuit.ctl
+++ b/tests/or_short_circuit.ctl
@@ -28,8 +28,8 @@ fn main() {
         println("bad 5");
     }
 
-    if passthrough(false, "good 6") or 
-       passthrough(false, "good 7") or 
+    if passthrough(false, "good 6") or
+       passthrough(false, "good 7") or
        passthrough(false, "good 8")
     {
         println("bad 6");

--- a/tests/patterns/arr_basic_destr.ctl
+++ b/tests/patterns/arr_basic_destr.ctl
@@ -8,16 +8,16 @@
 // Output: 1 2 3 4
 
 fn main() {
-    let funcs = @[
-        &subscript, 
-        val::end, 
-        val::start, 
+    let funcs = [
+        &subscript,
+        val::end,
+        val::start,
         val::mid,
         ptr::regular,
         ptr::end,
         ptr::start,
         ptr::mid,
-    ];
+    ][..];
     for func in funcs.iter() {
         let a = [1, 2, 3, 4];
         mut b = [5, 6, 7, 8];

--- a/tests/patterns/span_basic.ctl
+++ b/tests/patterns/span_basic.ctl
@@ -1,12 +1,8 @@
-// Output: true
-// Output: true
-// Output: true
-// Output: true
-// Output: true
+// Output: true true true true true
 
 fn main() {
-    mut vec = @[10, 10, 10, 10, 10];
-    match vec.as_span_mut() {
+    mut vec = [10, 10, 10, 10, 10][..];
+    match vec {
         [a, b, ...mid, c, d] => {
             *a = 1;
             *b = 2;
@@ -14,11 +10,11 @@ fn main() {
             *c = 4;
             *d = 5;
 
-            println("{*vec.get(0)! == 1}");
-            println("{*vec.get(1)! == 2}");
-            println("{*vec.get(2)! == 3}");
-            println("{*vec.get(3)! == 4}");
-            println("{*vec.get(4)! == 5}");
+            print("{*vec.get(0)! == 1} ");
+            print("{*vec.get(1)! == 2} ");
+            print("{*vec.get(2)! == 3} ");
+            print("{*vec.get(3)! == 4} ");
+            print("{*vec.get(4)! == 5} ");
         }
         _ => {
             println("span pattern didnt match");

--- a/tests/patterns/span_nested_destr.ctl
+++ b/tests/patterns/span_nested_destr.ctl
@@ -9,8 +9,8 @@ struct Foo {
 }
 
 fn main() {
-    mut vec = @[Foo(a: 10, b: 10), Foo(a: 10, b: 10)];
-    match vec.as_span_mut() {
+    let vec = [Foo(a: 10, b: 10), Foo(a: 10, b: 10)][..];
+    match vec {
         [{a, b}, {a: a2, b: b2}] => {
             *a = 1;
             *b = 2;

--- a/tests/patterns/span_ptr_destructure.ctl
+++ b/tests/patterns/span_ptr_destructure.ctl
@@ -1,7 +1,4 @@
-// Output: true
-// Output: true
-// Output: true
-// Output: true
+// Output: 1 2 3 4
 
 struct Foo {
     a: int,
@@ -11,17 +8,13 @@ struct Foo {
 fn main() {
     mut fooa = Foo(a: 10, b: 10);
     mut foob = Foo(a: 10, b: 10);
-    match @[&mut fooa, &mut foob].as_span_mut() {
+    match [&mut fooa, &mut foob][..] {
         [{a, b}, {a: a2, b: b2}] => {
             *a = 1;
             *b = 2;
             *a2 = 3;
             *b2 = 4;
-
-            println("{fooa.a == 1}");
-            println("{fooa.b == 2}");
-            println("{foob.a == 3}");
-            println("{foob.b == 4}");
+            print("{fooa.a} {fooa.b} {foob.a} {foob.b}");
         }
         _ => {
             println("span pattern didnt match");

--- a/tests/std/span_ranges.ctl
+++ b/tests/std/span_ranges.ctl
@@ -5,10 +5,10 @@
 // Output: true
 
 fn main() {
-    mut x = @[1, 2, 3, 4].as_span();
-    println("{std::span::compare(x[1u..2u], @[2][..])}");
-    println("{std::span::compare(x[1u..=2u], @[2, 3][..])}");
-    println("{std::span::compare(x[..2u], @[1, 2][..])}");
-    println("{std::span::compare(x[..=2u], @[1, 2, 3][..])}");
-    println("{std::span::compare(x[..], @[1, 2, 3, 4][..])}");
+    mut x = [1, 2, 3, 4][..];
+    println("{x[1u..2u]  == [2][..].as_span()}");
+    println("{x[1u..=2u] == [2, 3][..].as_span()}");
+    println("{x[..2u]    == [1, 2][..].as_span()}");
+    println("{x[..=2u]   == [1, 2, 3][..].as_span()}");
+    println("{x[..]      == [1, 2, 3, 4][..].as_span()}");
 }

--- a/tests/std/vec/list_init.ctl
+++ b/tests/std/vec/list_init.ctl
@@ -1,15 +1,7 @@
-// Output: 3
-// Output: 3
-// Output: 2
-// Output: 1
-// Output: true
+// Output: 3 Some(3) Some(2) Some(1) null
 
 fn main() {
     mut x = @[1, 2, 3];
-    println("{x.len()}");
-    println("{x.pop()!}");
-    println("{x.pop()!}");
-    println("{x.pop()!}");
-    println("{x.pop() is null}");
+    print("{x.len()} {x.pop()} {x.pop()} {x.pop()} {x.pop()}");
 }
 

--- a/tests/std/vec/push_insert.ctl
+++ b/tests/std/vec/push_insert.ctl
@@ -1,5 +1,5 @@
 // Output: 3
-// Output: 4 Some(3) Some(2) Some(4) Some(1) true
+// Output: 4 Some(3) Some(2) Some(4) Some(1) null
 
 fn main() {
     mut x: [int] = @[];

--- a/tests/std/vec/push_insert.ctl
+++ b/tests/std/vec/push_insert.ctl
@@ -1,10 +1,5 @@
 // Output: 3
-// Output: 4
-// Output: 3
-// Output: 2
-// Output: 4
-// Output: 1
-// Output: true
+// Output: 4 Some(3) Some(2) Some(4) Some(1) true
 
 fn main() {
     mut x: [int] = @[];
@@ -14,11 +9,5 @@ fn main() {
     println("{x.len()}");
 
     x.insert(idx: 1, 4);
-    println("{x.len()}");
-
-    println("{x.pop()!}");
-    println("{x.pop()!}");
-    println("{x.pop()!}");
-    println("{x.pop()!}");
-    println("{x.pop() is null}");
+    println("{x.len()} {x.pop()} {x.pop()} {x.pop()} {x.pop()} {x.pop()}");
 }

--- a/tests/std/vec/remove.ctl
+++ b/tests/std/vec/remove.ctl
@@ -11,5 +11,5 @@ fn main() {
     println("{vec.len()}");
     println("{vec.remove(3)}");
     println("{vec.len()}");
-    println("{std::span::compare(vec.as_span(), @[1, 7, 3, 5, 6].as_span())}");
+    println("{vec.as_span() == [1, 7, 3, 5, 6][..].as_span()}");
 }


### PR DESCRIPTION
This uses `infer_type_args`, like a function, to allow matching any type against the extension's `for` type.

